### PR TITLE
Support when for multiple calls with kwargs

### DIFF
--- a/src/main/python/fluentmock/__init__.py
+++ b/src/main/python/fluentmock/__init__.py
@@ -249,8 +249,7 @@ class FluentAnswer(FluentCallEntry):
     def __eq__(self, other):
         if not isinstance(other, FluentAnswer):
             return False
-        return self.arguments == other.arguments \
-               and self.keyword_arguments == other.keyword_arguments
+        return self.arguments == other.arguments and self.keyword_arguments == other.keyword_arguments
 
 
 class FluentPatchEntry(object):

--- a/src/main/python/fluentmock/__init__.py
+++ b/src/main/python/fluentmock/__init__.py
@@ -246,6 +246,12 @@ class FluentAnswer(FluentCallEntry):
         self._answers.append(answer)
         return self
 
+    def __eq__(self, other):
+        if not isinstance(other, FluentAnswer):
+            return False
+        return self.arguments == other.arguments \
+               and self.keyword_arguments == other.keyword_arguments
+
 
 class FluentPatchEntry(object):
 
@@ -286,7 +292,7 @@ class FluentMock(FluentTarget):
     def append_new_answer(self, new_answer):
 
         for answer in self._answers:
-            if answer.arguments == new_answer.arguments:
+            if answer == new_answer:
                 self._answers.remove(answer)
 
         self._answers.append(new_answer)

--- a/src/unittest/python/when_tests.py
+++ b/src/unittest/python/when_tests.py
@@ -154,6 +154,22 @@ class WhenTests(UnitTests):
         assert_that(targetpackage.targetfunction(2), equal_to(2))
         assert_that(targetpackage.targetfunction(0), equal_to(None))
 
+    def test_should_return_specific_values_with_same_args_and_diff_kwargs(self):
+
+        when(targetpackage).targetfunction(1, foo='bar').then_return('bar')
+        when(targetpackage).targetfunction(1, foo='baz').then_return('baz')
+
+        assert_that(targetpackage.targetfunction(1, foo='bar'), equal_to('bar'))
+        assert_that(targetpackage.targetfunction(1, foo='baz'), equal_to('baz'))
+
+    def test_should_return_specific_values_with_diff_args_and_same_kwargs(self):
+
+        when(targetpackage).targetfunction(1, foo='bar').then_return('boo')
+        when(targetpackage).targetfunction(2, foo='bar').then_return('zoo')
+
+        assert_that(targetpackage.targetfunction(1, foo='bar'), equal_to('boo'))
+        assert_that(targetpackage.targetfunction(2, foo='bar'), equal_to('zoo'))
+
     def test_should_patch_away_method_of_object(self):
 
         test_object = targetpackage.TheClass()


### PR DESCRIPTION
'when' does not work for multiple calls when args are same but kwargs
differ. This is because an answer is not added if an answer with the
same args (not kwargs) already exists. kwargs must also be evaluated for
2 answers to be equal. Add an __eq__ method on FluentAnswer that checks
for both args and kwargs.

https://github.com/aelgru/fluentmock/issues/40