### PR TITLE
Support 'when' for class methods

### DIFF
--- a/src/main/python/fluentmock/__init__.py
+++ b/src/main/python/fluentmock/__init__.py
@@ -49,7 +49,7 @@ from mock import Mock, call, patch
 
 from logging import getLogger
 from unittest import TestCase
-from types import ModuleType, TypeType
+from types import ModuleType
 
 from fluentmock.exceptions import (InvalidAttributeError,
                                    InvalidUseOfAnyValuesError,
@@ -121,7 +121,7 @@ class FluentTarget(object):
         elif isinstance(target, ModuleType):
             self.name = target.__name__
             self.object = import_module(self.name)
-        elif isinstance(target, TypeType):
+        elif isinstance(target, type):
             self.name = target.__module__ + '.' + target.__name__
             self.object = target
         else:

--- a/src/main/python/fluentmock/__init__.py
+++ b/src/main/python/fluentmock/__init__.py
@@ -49,7 +49,7 @@ from mock import Mock, call, patch
 
 from logging import getLogger
 from unittest import TestCase
-from types import ModuleType
+from types import ModuleType, TypeType
 
 from fluentmock.exceptions import (InvalidAttributeError,
                                    InvalidUseOfAnyValuesError,
@@ -121,6 +121,9 @@ class FluentTarget(object):
         elif isinstance(target, ModuleType):
             self.name = target.__name__
             self.object = import_module(self.name)
+        elif isinstance(target, TypeType):
+            self.name = target.__module__ + '.' + target.__name__
+            self.object = target
         else:
             target_type = type(target)
             self.name = target_type.__module__ + '.' + target_type.__name__

--- a/src/main/python/fluentmock/__init__.py
+++ b/src/main/python/fluentmock/__init__.py
@@ -49,7 +49,7 @@ from mock import Mock, call, patch
 
 from logging import getLogger
 from unittest import TestCase
-from types import ModuleType
+import types
 
 from fluentmock.exceptions import (InvalidAttributeError,
                                    InvalidUseOfAnyValuesError,
@@ -115,13 +115,17 @@ class UnitTests(TestCase):
 class FluentTarget(object):
 
     def __init__(self, target, attribute_name=None):
+        class_types = {type,
+                       getattr(types, 'ClassType')
+                       if hasattr(types, 'ClassType')
+                       else type}
         if isinstance(target, str):
             self.name = target
             self.object = import_module(self.name)
-        elif isinstance(target, ModuleType):
+        elif isinstance(target, types.ModuleType):
             self.name = target.__name__
             self.object = import_module(self.name)
-        elif isinstance(target, type):
+        elif type(target) in class_types:
             self.name = target.__module__ + '.' + target.__name__
             self.object = target
         else:

--- a/src/main/python/fluentmock/__init__.py
+++ b/src/main/python/fluentmock/__init__.py
@@ -115,10 +115,10 @@ class UnitTests(TestCase):
 class FluentTarget(object):
 
     def __init__(self, target, attribute_name=None):
-        class_types = {type,
+        class_types = (type,
                        getattr(types, 'ClassType')
                        if hasattr(types, 'ClassType')
-                       else type}
+                       else type)
         if isinstance(target, str):
             self.name = target
             self.object = import_module(self.name)

--- a/src/unittest/python/targetpackage/__init__.py
+++ b/src/unittest/python/targetpackage/__init__.py
@@ -39,5 +39,15 @@ class TheClass(object):
         sys.stdout.write("WARNING! Actual method has been called.\n")
 
 
+class TheOldStyleClass:
+
+    def some_method(self):
+        sys.stdout.write("WARNING! Actual method has been called.\n")
+
+    @classmethod
+    def some_class_method(self):
+        sys.stdout.write("WARNING! Actual method has been called.\n")
+
+
 def call_a_subprocess():
     call(['pip'], stderr=STDOUT)

--- a/src/unittest/python/targetpackage/__init__.py
+++ b/src/unittest/python/targetpackage/__init__.py
@@ -34,6 +34,10 @@ class TheClass(object):
     def some_method(self):
         sys.stdout.write("WARNING! Actual method has been called.\n")
 
+    @classmethod
+    def some_class_method(self):
+        sys.stdout.write("WARNING! Actual method has been called.\n")
+
 
 def call_a_subprocess():
     call(['pip'], stderr=STDOUT)

--- a/src/unittest/python/when_tests.py
+++ b/src/unittest/python/when_tests.py
@@ -178,13 +178,21 @@ class WhenTests(UnitTests):
 
         assert_that(test_object.some_method(1), equal_to(0))
 
-    def test_should_patch_away_class_method(self):
+    def test_should_patch_away_class_method_for_new_style_classes(self):
 
         when(targetpackage.TheClass).some_class_method(1).then_return(10)
         when(targetpackage.TheClass).some_class_method(2).then_return(11)
 
         assert_that(targetpackage.TheClass.some_class_method(1), equal_to(10))
         assert_that(targetpackage.TheClass.some_class_method(2), equal_to(11))
+
+    def test_should_patch_away_class_method_for_old_style_classes(self):
+
+        when(targetpackage.TheOldStyleClass).some_class_method(1).then_return(10)
+        when(targetpackage.TheOldStyleClass).some_class_method(2).then_return(11)
+
+        assert_that(targetpackage.TheOldStyleClass.some_class_method(1), equal_to(10))
+        assert_that(targetpackage.TheOldStyleClass.some_class_method(2), equal_to(11))
 
     def test_should_give_useful_feedback_if_target_does_not_have_attribute(self):
 

--- a/src/unittest/python/when_tests.py
+++ b/src/unittest/python/when_tests.py
@@ -178,6 +178,14 @@ class WhenTests(UnitTests):
 
         assert_that(test_object.some_method(1), equal_to(0))
 
+    def test_should_patch_away_class_method(self):
+
+        when(targetpackage.TheClass).some_class_method(1).then_return(10)
+        when(targetpackage.TheClass).some_class_method(2).then_return(11)
+
+        assert_that(targetpackage.TheClass.some_class_method(1), equal_to(10))
+        assert_that(targetpackage.TheClass.some_class_method(2), equal_to(11))
+
     def test_should_give_useful_feedback_if_target_does_not_have_attribute(self):
 
         exception_raised = False


### PR DESCRIPTION
Patching for class methods is broken. Add an extra condition to patch class
methods. The following test is broken
```python
        when(targetpackage.TheClass).some_class_method(1).then_return(10)
        when(targetpackage.TheClass).some_class_method(2).then_return(11)

        assert_that(targetpackage.TheClass.some_class_method(1), equal_to(10))
        assert_that(targetpackage.TheClass.some_class_method(2), equal_to(11))
```